### PR TITLE
Extensions and Resource-bugfix, build update

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,8 +6,8 @@ apply plugin: 'com.jfrog.bintray'
 version = "1.0.2.3"
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.2"
     resourcePrefix "wpedittext__"
 
     defaultConfig {
@@ -31,7 +31,7 @@ task wrapper(type: org.gradle.api.tasks.wrapper.Wrapper) {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.0.0'
+    compile 'com.android.support:appcompat-v7:23.1.1'
 }
 
 // https://www.virag.si/2015/01/publishing-gradle-android-library-to-jcenter/

--- a/app/src/main/java/org/webpartners/wpedittext/WPEditText.java
+++ b/app/src/main/java/org/webpartners/wpedittext/WPEditText.java
@@ -7,6 +7,7 @@ import android.support.v4.content.ContextCompat;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextWatcher;
+import android.text.method.KeyListener;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -49,6 +50,7 @@ public class WPEditText extends LinearLayout implements TextWatcher {
     private final String numericWithSpaceAndPlusPattern= "^[\\s0-9+]*$";
 
     private boolean ok = false;
+    private KeyListener cachedKeyListener;
 
     public WPEditText(Context context) {
         super(context);
@@ -71,11 +73,12 @@ public class WPEditText extends LinearLayout implements TextWatcher {
             this.setupEditText(
                     a.getResourceId(R.styleable.wpedittext__style_wpedittext__hint, R.string.wpedittext__sample_hint),
                     a.getInteger(R.styleable.wpedittext__style_wpedittext__type, TYPE_ALPHANUMERIC),
-                    a.getInteger(R.styleable.wpedittext__style_wpedittext__min_length, 8)
+                    a.getInteger(R.styleable.wpedittext__style_wpedittext__min_length, 8),
+                    a.getBoolean(R.styleable.wpedittext__style_wpedittext__editable, true)
             );
             this.textColors(
-                    a.getColor(R.styleable.wpedittext__style_wpedittext__text_color, android.R.color.black),
-                    a.getColor(R.styleable.wpedittext__style_wpedittext__hint_color, android.R.color.darker_gray)
+                    a.getResourceId(R.styleable.wpedittext__style_wpedittext__text_color, android.R.color.black),
+                    a.getResourceId(R.styleable.wpedittext__style_wpedittext__hint_color, android.R.color.darker_gray)
             );
             this.validationText(
                     a.getString(R.styleable.wpedittext__style_wpedittext__valid_message),
@@ -117,17 +120,10 @@ public class WPEditText extends LinearLayout implements TextWatcher {
      * @param type A {@link} Type for validate entered text
      * @param minLength Min length (recommended for passwords)
      */
-    public void setupEditText(int hint, int type, int minLength) {
-        this.editText.setHint(hint);
-        this.type = type;
+    public void setupEditText(int hint, int type, int minLength, boolean editable) {
         this.minLength = minLength;
-
-        switch (type) {
-            case TYPE_PASSWORD:
-                this.editText.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
-                this.editText.setRawInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
-                break;
-        }
+        setEditable(editable);
+        setupEditText(hint, type);
     }
 
     /**
@@ -153,6 +149,18 @@ public class WPEditText extends LinearLayout implements TextWatcher {
      */
     public void setupEditText(String hint) {
         this.editText.setHint(hint);
+    }
+
+    public  void setEditable(boolean editable) {
+        underline.setVisibility(editable ?  VISIBLE : INVISIBLE);
+        isValid.setVisibility(editable ?  VISIBLE : INVISIBLE);
+        if (!editable) {
+            this.cachedKeyListener = this.editText.getKeyListener();
+            this.editText.setKeyListener(null);
+        } else {
+            if (cachedKeyListener != null)
+                this.editText.setKeyListener(cachedKeyListener);
+        }
     }
 
     /**
@@ -279,5 +287,9 @@ public class WPEditText extends LinearLayout implements TextWatcher {
 
     @Override
     public void afterTextChanged(Editable s) {}
+
+    public void addTextChangedListener(TextWatcher watcher) {
+        editText.addTextChangedListener(watcher);
+    }
 
 }

--- a/app/src/main/java/org/webpartners/wpedittext/WPEditText.java
+++ b/app/src/main/java/org/webpartners/wpedittext/WPEditText.java
@@ -2,6 +2,8 @@ package org.webpartners.wpedittext;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.support.annotation.ColorRes;
+import android.support.v4.content.ContextCompat;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextWatcher;
@@ -22,6 +24,9 @@ public class WPEditText extends LinearLayout implements TextWatcher {
     public static final int TYPE_ALPHANUMERIC = 1;
     public static final int TYPE_EMAIL = 2;
     public static final int TYPE_PASSWORD = 3;
+    public static final int TYPE_NUMERIC = 4;
+    public static final int TYPE_NUMERIC_WITH_SPACE = 5;
+    public static final int TYPE_NUMERIC_WITH_SPACE_AND_PLUS = 6;
 
     private Context context;
 
@@ -39,6 +44,9 @@ public class WPEditText extends LinearLayout implements TextWatcher {
     private final String alphaPattern= "^[a-z\\sA-Z]*$";
     private final String alphaNumericPattern= "^[a-z\\sA-Z0-9]*$";
     private final String emailPattern= "^(.+)@([^@]+[^.])$";
+    private final String numeric= "^[0-9]*$";
+    private final String numericWithSpacePattern= "^[\\s0-9]*$";
+    private final String numericWithSpaceAndPlusPattern= "^[\\s0-9+]*$";
 
     private boolean ok = false;
 
@@ -152,9 +160,9 @@ public class WPEditText extends LinearLayout implements TextWatcher {
      * @param textColor Resource id
      * @param hintColor Resource id
      */
-    public void textColors(int textColor, int hintColor) {
-        this.editText.setTextColor(context.getResources().getColor(textColor));
-        this.editText.setHintTextColor(context.getResources().getColor(hintColor));
+    public void textColors(@ColorRes int textColor, @ColorRes int hintColor) {
+        this.editText.setTextColor(ContextCompat.getColor(context, textColor));
+        this.editText.setHintTextColor(ContextCompat.getColor(context, hintColor));
     }
 
     /**
@@ -243,6 +251,15 @@ public class WPEditText extends LinearLayout implements TextWatcher {
                 break;
             case TYPE_EMAIL:
                 this.ok = s.toString().matches(this.emailPattern);
+                break;
+            case TYPE_NUMERIC:
+                this.ok = s.toString().matches(this.numeric);
+                break;
+            case TYPE_NUMERIC_WITH_SPACE:
+                this.ok = s.toString().matches(this.numericWithSpacePattern);
+                break;
+            case TYPE_NUMERIC_WITH_SPACE_AND_PLUS:
+                this.ok = s.toString().matches(this.numericWithSpaceAndPlusPattern);
                 break;
         }
 

--- a/app/src/main/java/org/webpartners/wpedittext/WPEditText.java
+++ b/app/src/main/java/org/webpartners/wpedittext/WPEditText.java
@@ -64,29 +64,29 @@ public class WPEditText extends LinearLayout implements TextWatcher {
 
         TypedArray a = context.getTheme().obtainStyledAttributes(
                 attributeSet,
-                R.styleable.wpedittext__style,
+                R.styleable.WPEditText,
                 0, 0);
 
         init();
 
         try {
             this.setupEditText(
-                    a.getResourceId(R.styleable.wpedittext__style_wpedittext__hint, R.string.wpedittext__sample_hint),
-                    a.getInteger(R.styleable.wpedittext__style_wpedittext__type, TYPE_ALPHANUMERIC),
-                    a.getInteger(R.styleable.wpedittext__style_wpedittext__min_length, 8),
-                    a.getBoolean(R.styleable.wpedittext__style_wpedittext__editable, true)
+                    a.getResourceId(R.styleable.WPEditText_hint, R.string.wpedittext__sample_hint),
+                    a.getInteger(R.styleable.WPEditText_type, TYPE_ALPHANUMERIC),
+                    a.getInteger(R.styleable.WPEditText_min_length, 8),
+                    a.getBoolean(R.styleable.WPEditText_editable, true)
             );
             this.textColors(
-                    a.getResourceId(R.styleable.wpedittext__style_wpedittext__text_color, android.R.color.black),
-                    a.getResourceId(R.styleable.wpedittext__style_wpedittext__hint_color, android.R.color.darker_gray)
+                    a.getResourceId(R.styleable.WPEditText_text_color,  android.R.color.black),
+                    a.getResourceId(R.styleable.WPEditText_hint_color, android.R.color.darker_gray)
             );
             this.validationText(
-                    a.getString(R.styleable.wpedittext__style_wpedittext__valid_message),
-                    a.getString(R.styleable.wpedittext__style_wpedittext__invalid_message),
-                    a.getString(R.styleable.wpedittext__style_wpedittext__empty_message)
+                    a.getString(R.styleable.WPEditText_valid_message),
+                    a.getString(R.styleable.WPEditText_invalid_message),
+                    a.getString(R.styleable.WPEditText_empty_message)
             );
             this.icon(a.getResourceId(
-                    R.styleable.wpedittext__style_wpedittext__header_icon,
+                    R.styleable.WPEditText_header_icon,
                     android.R.drawable.ic_dialog_info)
             );
         } finally {

--- a/app/src/main/res/layout/wpedittext__component.xml
+++ b/app/src/main/res/layout/wpedittext__component.xml
@@ -14,6 +14,7 @@
             android:layout_height="match_parent"/>
 
         <RelativeLayout
+            android:layout_marginLeft="@dimen/icon_text_margin"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 

--- a/app/src/main/res/layout/wpedittext__test.xml
+++ b/app/src/main/res/layout/wpedittext__test.xml
@@ -9,14 +9,14 @@
     <org.webpartners.wpedittext.WPEditText
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        wp:wpedittext__hint="@string/wpedittext__sample_hint"
-        wp:wpedittext__type="alpha"
-        wp:wpedittext__min_length="8"
-        wp:wpedittext__valid_message="@string/wpedittext__validation_valid_field"
-        wp:wpedittext__invalid_message="@string/wpedittext__validation_invalid_field"
-        wp:wpedittext__empty_message="@string/wpedittext__validation_empty_field"
-        wp:wpedittext__text_color="@android:color/black"
-        wp:wpedittext__hint_color="@android:color/darker_gray"
-        wp:wpedittext__header_icon="@android:drawable/ic_dialog_info"/>
+        wp:hint="@string/wpedittext__sample_hint"
+        wp:type="alpha"
+        wp:min_length="8"
+        wp:valid_message="@string/wpedittext__validation_valid_field"
+        wp:invalid_message="@string/wpedittext__validation_invalid_field"
+        wp:empty_message="@string/wpedittext__validation_empty_field"
+        wp:text_color="@android:color/black"
+        wp:hint_color="@android:color/darker_gray"
+        wp:header_icon="@android:drawable/ic_dialog_info"/>
 
 </LinearLayout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -10,11 +10,15 @@
         <attr name="wpedittext__text_color" format="reference"/>
         <attr name="wpedittext__hint_color" format="reference"/>
         <attr name="wpedittext__header_icon" format="reference"/>
+        <attr name="wpedittext__editable" format="boolean"/>
         <attr name="wpedittext__type" format="enum">
             <enum name="alpha" value="0"/>
             <enum name="alphanumeric" value="1"/>
             <enum name="email" value="2"/>
             <enum name="password" value="3"/>
+            <enum name="numeric" value="4"/>
+            <enum name="numericWithSpace" value="5"/>
+            <enum name="numericWithSpaceAndPlus" value="6"/>
         </attr>
     </declare-styleable>
 </resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <declare-styleable name="wpedittext__style">
-        <attr name="wpedittext__hint" format="reference"/>
-        <attr name="wpedittext__min_length" format="integer"/>
-        <attr name="wpedittext__valid_message" format="reference"/>
-        <attr name="wpedittext__invalid_message" format="reference"/>
-        <attr name="wpedittext__empty_message" format="reference"/>
-        <attr name="wpedittext__underline_color" format="reference"/>
-        <attr name="wpedittext__text_color" format="reference"/>
-        <attr name="wpedittext__hint_color" format="reference"/>
-        <attr name="wpedittext__header_icon" format="reference"/>
-        <attr name="wpedittext__editable" format="boolean"/>
-        <attr name="wpedittext__type" format="enum">
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <!-- We want these resources exported so they have not been prefixed with wpedittext__-->
+    <declare-styleable name="WPEditText" tools:ignore="ResourceName">
+        <attr name="hint" format="reference"/>
+        <attr name="min_length" format="integer"/>
+        <attr name="valid_message" format="reference"/>
+        <attr name="invalid_message" format="reference"/>
+        <attr name="empty_message" format="reference"/>
+        <attr name="underline_color" format="reference"/>
+        <attr name="text_color" format="reference"/>
+        <attr name="hint_color" format="reference"/>
+        <attr name="header_icon" format="reference"/>
+        <attr name="editable" format="boolean"/>
+        <attr name="type" format="enum">
             <enum name="alpha" value="0"/>
             <enum name="alphanumeric" value="1"/>
             <enum name="email" value="2"/>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="icon_text_margin">0dp</dimen>
+</resources>


### PR DESCRIPTION
The latest commit removes resourcePrefix from attributes. I use Android studio preview 2.0 and gradle 1.5. When building with resourcePrefix it the attributes are not exported. I suspect this might be because Android does not export resources with resourcePrefix. I havn't been able to find any documentation by searching Google though. I left the resource prefix on strings which we don't need exported.

If you don't want to include the stripping of resourcePrefix,the two first commits still bring value, I believe.
